### PR TITLE
Modernize library

### DIFF
--- a/hazelnut/__init__.py
+++ b/hazelnut/__init__.py
@@ -7,4 +7,4 @@ __author__ = 'Martin Simon <me@martinsimon.me>'
 __repo__ = 'https://github.com/c0ding/hazelnut'
 __license__ = 'Apache v2.0 License'
 
-from core import MemInfo
+from .core import MemInfo

--- a/hazelnut/core.py
+++ b/hazelnut/core.py
@@ -9,30 +9,29 @@ __author__ = 'Martin Simon <me@martinsimon.me>'
 __repo__ = 'https://github.com/c0ding/hazelnut'
 __license__ = 'Apache v2.0 License'
 
+
 class MemInfo(object):
+    def __init__(self, path='/proc/meminfo'):
+        self.path = path
 
-	def __init__(self, path='/proc/meminfo'):
-		self.path = path
+    def fileobj(self):
+        return open(self.get_path(), 'r')
 
-	def __str__(self):
-		with open(self.get_path(), 'r') as f:
-			lines = [line.strip() for line in f]
-		return '\n'.join(lines)
+    def __str__(self):
+        with self.fileobj() as f:
+            lines = [line.strip() for line in f]
+            return '\n'.join(lines)
 
-	def __repr__(self):
-		return self.__str__()
+    def __repr__(self):
+        return self.__str__()
 
-	def get_path(self):
-		return self.path
-	
-	def dict(self):
-		d = {}
-		with open(self.get_path(), 'r') as f:
-			d = dict(x.strip().split(None, 1) for x in f)
-		return d
+    def dict(self):
+        with self.fileobj() as f:
+            d = dict(x.strip().split(None, 1) for x in f)
+        return d
 
-	def search(self, user_inp):
-		with open(self.get_path(), 'r') as f:
-			matcher = re.compile(user_inp, re.IGNORECASE)
-			match = filter(matcher.match, f) 
-		return match
+    def search(self, regex):
+        with self.fileobj() as f:
+            matcher = re.compile(regex, re.IGNORECASE)
+            match = filter(matcher.match, f)
+            return match

--- a/hazelnut/core.py
+++ b/hazelnut/core.py
@@ -3,12 +3,6 @@
 
 import re
 
-__title__ = 'hazelnut'
-__version__ = '0.2'
-__author__ = 'Martin Simon <me@martinsimon.me>'
-__repo__ = 'https://github.com/c0ding/hazelnut'
-__license__ = 'Apache v2.0 License'
-
 
 class MemInfo(object):
     def __init__(self, path='/proc/meminfo'):

--- a/setup.py
+++ b/setup.py
@@ -4,15 +4,15 @@
 from distutils.core import setup
 
 setup(
-	name = 'hazelnut',
-	version = '0.2',
-	url = 'https://github.com/c0ding/hazelnut',
-	download_url = 'https://github.com/c0ding/hazelnut/archive/master.zip',
-	author = 'Martin Simon',
-	author_email = 'me@martinsimon.me',
-	license = 'Apache v2.0 License',
-	packages = ['hazelnut'],
-	description = 'A pythonic library to parse /proc/meminfo',
-	long_description = file('README.md','r').read(),
-	keywords = ['memory', 'RAM', 'system information', 'meminfo', '/proc'],
+    name='hazelnut',
+    version='0.2',
+    url='https://github.com/c0ding/hazelnut',
+    download_url='https://github.com/c0ding/hazelnut/archive/master.zip',
+    author='Martin Simon',
+    author_email='me@martinsimon.me',
+    license='Apache v2.0 License',
+    packages=['hazelnut'],
+    description='A pythonic library to parse /proc/meminfo',
+    long_description=file('README.md','r').read(),
+    keywords=['memory', 'RAM', 'system information', 'meminfo', '/proc'],
 )


### PR DESCRIPTION
Hi, first of all I would like to say that the library a true "unix"-style library, in that it does it's job and is extremely simple. However I was slightly _horrified_, for the lack of a better word, when reading the codebase, so  I modernized the library and comply with PEP8. Better expressed as a list of changes:
- Use 4 spaces instead of tabs.
- Fixed an import error in `__init__.py`
- Removed metadata included in the `core.py` file
- Removed `MemInfo.get_path()` as that is not necessary, since `Meminfo.path` is already exposed.
- Removed leading and trailing spaces when calling `setup()` in the `setup.py` file.
