### PR TITLE
Use list comprehension and lazy iteration

### DIFF
--- a/hazelnut/core.py
+++ b/hazelnut/core.py
@@ -28,13 +28,12 @@ class MemInfo(object):
     def search(self, regex):
         with self.fileobj() as f:
             matcher = re.compile(regex, re.IGNORECASE)
-            match = filter(matcher.match, f)
-        return match
+            return [k for k in f if matcher.match(k)]
 
     def get(self, string):
         with self.fileobj() as f:
-            lines = [line.strip() for line in f]
-            for item in lines:
-                if item.startswith(string):
-                    match = re.findall(r'([0-9]+)\s', item)
+            for item in f:
+                line = item.strip()
+                if line.startswith(string):
+                    match = re.findall(r'([0-9]+)\s', line)
                     return int(match[0])


### PR DESCRIPTION
For `MemInfo.search`, [Python 3's `filter`](https://docs.python.org/3/library/functions.html#filter) returns a generator object which is not a list (but can be iterated). We force it to become a list by using list comprehensions which are more expressive at the same time. The same can be done by doing `list(filter(...))` but that requires the list to be iterated twice.

For `MemInfo.get`, we don't need to consume the whole file before processing. We can do stream processing via [`file.next`](https://docs.python.org/2/library/stdtypes.html#file.next) to avoid needing to read the whole file into memory.
