### PR TITLE
Added a `convert` method that returns a dictionary of the converted size values

### DIFF
--- a/hazelnut/core.py
+++ b/hazelnut/core.py
@@ -25,6 +25,30 @@ class MemInfo(object):
             d = {key.strip(':'): item.strip() for key, item in d.items()}
         return d
 
+    def convert(self, size):
+        size = size.lower()
+        d = self.dict()
+        for data in d:
+            mem = d[data]
+            if size == "gb" or size == "gigabyte":
+                mem = mem.split()
+                if len(data) > 1:
+                    gb = int(mem[0]) / 1024.0**2
+                    d[data] = str(gb) + " gb"
+            
+            elif size == "mb" or size == "megabyte":
+                mem = mem.split()
+                if len(data) > 1:
+                    mb = int(mem[0]) / 1024.0
+                    d[data] = str(mb) + " mb"
+
+            elif size == "bytes":
+                mem = mem.split()
+                if len(data) > 1:
+                    bytes = int(mem[0]) * 1024.0
+                    d[data] = str(bytes) + " bytes"
+        return d
+                    
     def search(self, regex):
         with self.fileobj() as f:
             matcher = re.compile(regex, re.IGNORECASE)


### PR DESCRIPTION
I added a `convert` method which takes a string argument and returns a dictionary similar to what is returned by the `dict` method but with the converted memory values.

For example, the following code will return all of the results in Gigabytes:

```
import hazelnut
import pprint
info = hazelnut.MemInfo()
newData = info.convert("gb")
pprint.pprint(newData)
```

The output looks something like this:

```

{'Active': '2.03393173218 gb',
 'Active(anon)': '1.55102539062 gb',
 'Active(file)': '0.482906341553 gb',
 'AnonHugePages': '0.609375 gb',
 'AnonPages': '1.74890136719 gb',
 'Bounce': '0.0 gb',
 'Buffers': '0.244331359863 gb',
 'Cached': '0.912567138672 gb',
 'CommitLimit': '5.84342193604 gb',
 'Committed_AS': '7.62927246094 gb',
 'DirectMap2M': '0.80859375 gb',
 'DirectMap4k': '0.0624923706055 gb',
 'Dirty': '6.86645507812e-05 gb',
 'HardwareCorrupted': '0.0 gb',
 'HighFree': '0.543197631836 gb',
 'HighTotal': '3.04761505127 gb',
 'HugePages_Free': '0.0 gb',
 'HugePages_Rsvd': '0.0 gb',
 'HugePages_Surp': '0.0 gb',
 'HugePages_Total': '0.0 gb',
 'Hugepagesize': '0.001953125 gb',
 'Inactive': '0.910678863525 gb',
 'Inactive(anon)': '0.451427459717 gb',
 'Inactive(file)': '0.459251403809 gb',
 'KernelStack': '0.00552368164062 gb',
 'LowFree': '0.15295791626 gb',
 'LowTotal': '0.805255889893 gb',
 'Mapped': '0.247932434082 gb',
 'MemFree': '0.696155548096 gb',
 'MemTotal': '3.85287094116 gb',
 'Mlocked': '4.57763671875e-05 gb',
 'NFS_Unstable': '0.0 gb',
 'PageTables': '0.0229034423828 gb',
 'SReclaimable': '0.116142272949 gb',
 'SUnreclaim': '0.0296249389648 gb',
 'Shmem': '0.214740753174 gb',
 'Slab': '0.145767211914 gb',
 'SwapCached': '0.0921020507812 gb',
 'SwapFree': '3.53842926025 gb',
 'SwapTotal': '3.9169883728 gb',
 'Unevictable': '4.57763671875e-05 gb',
 'VmallocChunk': '0.0284004211426 gb',
 'VmallocTotal': '0.1171875 gb',
 'VmallocUsed': '0.0269393920898 gb',
 'Writeback': '0.0 gb',
 'WritebackTmp': '0.0 gb'}

```

The change supports Megabytes, Gigabytes, and Bytes
